### PR TITLE
Permute.js : change data and keep stride same

### DIFF
--- a/src/layers/core/Permute.js
+++ b/src/layers/core/Permute.js
@@ -1,5 +1,7 @@
 import Layer from '../../Layer'
-
+import Tensor from '../../Tensor'
+import ndarray from 'ndarray'
+import ops from 'ndarray-ops'
 /**
  * Permute layer class
  * Note there is no concept of batch size in these layers (single-batch), so dim numbers 1 less
@@ -30,6 +32,13 @@ export default class Permute extends Layer {
       throw new Error(`${this.name} [Permute layer] The specified dims permutation must match the number of dimensions.`)
     }
     x.tensor = x.tensor.transpose(...this.dims)
+    let permuted = new Tensor([], [x.tensor.shape[0],x.tensor.shape[1]])
+    for(var i=0; i<x.tensor.shape[0]; ++i) {
+        for(var j=0;j<x.tensor.shape[1];++j){
+            permuted.tensor.set(i,j,x.tensor.get(i,j))
+        }
+    } 
+    x.tensor = permuted.tensor
     return x
   }
 }


### PR DESCRIPTION
There is a minor yet important change required in the Permute layer implementation to get correct model predictions.
In Permute.js, the transpose of input data is created using the permute dimensions provided. Currently, the tensor's transpose is created by changing the `shape` and the `stride` (from the default row-major to column major) but keeping the `data` same. This is fine,but problem arises in later layers. For eg., in my case there is a `Merge concat` layer after the permute layer. The concatenation just concatenates the `data` from the two tensors without taking into account their `stride`. Hence, this doesn't throw any error but gives incorrect predictions.
My suggestion is to change the data and keep the stride same in Permute.js, since a default Tensor too has row-major stride.