### PR TITLE
Changing main to point to built files in dist/keras.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "keras-js",
   "version": "0.1.0",
   "description": "Run Keras models (tensorflow backend) in the browser, with GPU support",
-  "main": "lib/index.js",
+  "main": "dist/keras.js",
   "scripts": {
     "watch": "NODE_ENV=development BABEL_ENV=browser webpack --watch --config webpack.config.js",
     "build:browser": "rm -rf dist; NODE_ENV=production BABEL_ENV=browser webpack --config webpack.config.js",


### PR DESCRIPTION
I think maybe there was a mistake with a global find & replace here: https://github.com/transcranial/keras-js/commit/fb6527466490ecf6a978f97709ee8c5fcc39175a

`main` in `package.json` was pointing to the uncompiled files in `lib/index.js`. So when this package was installed with npm and required, it required compilation of everything in the `src` file. For example, it required `babel-polyfill`, `axios`, `glsl` files and other things that aren't really part of this library. 

This change tells applications who require `keras-js` to load the already compiled files. 