### PR TITLE
Add resetStates function for stateful rnns

### DIFF
--- a/src/Layer.js
+++ b/src/Layer.js
@@ -71,4 +71,11 @@ export default class Layer {
     this.output = x
     return this.output
   }
+
+  /**
+   * Reset presistent state in the mode. Only applies with stateful rnns.
+   */
+  resetStates() {
+    return
+  }
 }

--- a/src/Model.js
+++ b/src/Model.js
@@ -616,6 +616,15 @@ export default class Model {
   }
 
   /**
+   * Reset presistent state in the mode. Only applies with stateful rnns.
+   */
+  resetStates() {
+    this.modelLayersMap.forEach(layer => {
+      layer.resetStates()
+    })
+  }
+
+  /**
    * Cleanup - important for memory management
    */
   cleanup() {

--- a/src/layers/recurrent/GRU.js
+++ b/src/layers/recurrent/GRU.js
@@ -525,4 +525,8 @@ export default class GRU extends Layer {
       this.output.transferFromGLTexture()
     }
   }
+
+  resetStates() {
+    this.currentHiddenState = null
+  }
 }

--- a/src/layers/recurrent/LSTM.js
+++ b/src/layers/recurrent/LSTM.js
@@ -634,4 +634,9 @@ export default class LSTM extends Layer {
       this.output.transferFromGLTexture()
     }
   }
+
+  resetStates() {
+    this.previousCandidate = null
+    this.currentHiddenState = null
+  }
 }

--- a/src/layers/recurrent/SimpleRNN.js
+++ b/src/layers/recurrent/SimpleRNN.js
@@ -295,4 +295,8 @@ export default class SimpleRNN extends Layer {
       this.output.transferFromGLTexture()
     }
   }
+
+  resetStates() {
+    this.currentHiddenState = null
+  }
 }


### PR DESCRIPTION
No idea if this is of interest, but working on some web demos for rnn text generation with stateful rnns and sorely missed the `reset_states` function from keras. Added one in.

Probably plenty of ways to implement this too so happy to tweak.