### PR TITLE
fix TimeDistributed layer creation

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -382,7 +382,7 @@ export default class Model {
       )
       weightNames = forwardWeightNames.concat(backwardWeightNames)
     } else if (layerClass === 'TimeDistributed') {
-      weightNames = layer.layer.params.map(param => `${layerConfig.name}/${param}`)
+      weightNames = layer.wrappedLayer.params.map(param => `${layerConfig.name}/${param}`)
     } else {
       weightNames = layer.params.map(param => `${layerConfig.name}/${param}`)
     }


### PR DESCRIPTION
Had some trouble loading TimeDistributed layers, seems like this might be a simple bug in a old refactor...

The TimeDistributed.layer member was renamed wrappedLayer in
https://github.com/transcranial/keras-js/commit/641333107c1efd2f3727396066b36e83e64f760c

The model _createLayer function was still using the old name.