### PR TITLE
Minimal Lambda layer implementation

### DIFF
--- a/src/layers/core/Lambda.js
+++ b/src/layers/core/Lambda.js
@@ -1,0 +1,47 @@
+import Layer from '../../Layer'
+
+/**
+ * Lambda layer class
+ * This layer requires you to re-implement lambda nodes in javascript,
+ * as we do not have a python runtime available.
+ */
+export default class Lambda extends Layer {
+
+  /**
+   * Creates a Lambda layer
+   *
+   * @param {Object} [attrs] - layer config attributes
+   */
+  constructor(attrs = {}) {
+    super(attrs);
+    this.layerClass = 'Lambda';
+
+    if(this.functions[attrs.name]) {
+      this._call = this.functions[attrs.name].bind(this);
+    } else {
+      console.log("Missing lambda, using No_op! Implement it by defining require(\"keras-js/layers/core/Lambda\").functions["+attrs.name+"]");
+      this._call = x => ({output: x, inputShape: x.tensor.shape});
+    }
+
+    if(this.initializers[attrs.name]) {
+      this.initializers[attrs.name].bind(this)();
+    } else {
+      console.log("No lambda initializer. Disable this warning by defining require(\"keras-js/layers/core/Lambda\").initializers["+attrs.name+"]");
+    }
+  }
+
+  /**
+   * Method for layer computational logic
+   *
+   * @param {Tensor} x
+   * @returns {Tensor}
+   */
+  call(x) { 
+    return Object.assign(this, this._call(x)).output;
+  }
+
+}
+Lambda.prototype.functions = {};
+Lambda.prototype.initializers = {}
+
+exports.default = Lambda;

--- a/src/layers/core/index.js
+++ b/src/layers/core/index.js
@@ -5,6 +5,7 @@ import SpatialDropout1D from './SpatialDropout1D'
 import SpatialDropout2D from './SpatialDropout2D'
 import SpatialDropout3D from './SpatialDropout3D'
 import Flatten from './Flatten'
+import Lambda from './Lambda'
 import Reshape from './Reshape'
 import Permute from './Permute'
 import RepeatVector from './RepeatVector'
@@ -17,6 +18,7 @@ export {
   SpatialDropout2D,
   SpatialDropout3D,
   Flatten,
+  Lambda,
   Reshape,
   Permute,
   RepeatVector


### PR DESCRIPTION
I had a finished model and needed it to fit into keras-js. Seeing as I had some lambda layers in that model, it seemed like the easiest solution was to implement this in keras-js and push it back to master.

The implementation is more or less low-effort, but works perfectly fine for my scenario. There may be a cleaner method to push through the lambda functions, but I can't claim enough experience with keras-js to determine how that should be done.