### PR TITLE
Add another dimension to softmax

### DIFF
--- a/src/activations/softmax.js
+++ b/src/activations/softmax.js
@@ -20,6 +20,16 @@ export default function softmax(x) {
       const sum = ops.sum(x.tensor.pick(i, null))
       ops.divseq(x.tensor.pick(i, null), sum)
     }
+  } else if (x.tensor.shape.length === 3) {
+    for (let i=0; i< x.tensor.shape[0]; i++){
+      for(let j=0;j<x.tensor.shape[1]; j++){
+        const maxval = _ndarrayOps.default.sup(x.tensor.pick(i,j,null));
+        _ndarrayOps.default.subseq(x.tensor.pick(i,j, null), maxval);
+        _ndarrayOps.default.expeq(x.tensor.pick(i,j, null));
+        const sum = _ndarrayOps.default.sum(x.tensor.pick(i,j, null));
+        _ndarrayOps.default.divseq(x.tensor.pick(i,j, null), sum);
+      }
+    }
   } else {
     throw new Error(`[activations.softmax] tensor shape ${x.tensor.shape} not supported.`)
   }


### PR DESCRIPTION
The softmax activation in the model I received was in three dimensions, so I added support for that layer shape to the CPU version of the softmax activation by simply extending another dimension to the library implementation. Wouldn't mind if someone takes a look at a 3D-GPU version? :1234: :)